### PR TITLE
feat: add otel tracing support

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,16 @@
+name: Typecheck
+
+on:
+  pull_request:
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+      - name: Install dependencies
+        run: bun i
+      - name: Run typecheck
+        run: bun typecheck

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,6 @@
         "@escape.tech/graphql-armor": "^3.2.0",
         "@graphql-yoga/plugin-disable-introspection": "^2.19.0",
         "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/semantic-conventions": "^1.39.0",
         "@pothos/core": "^4.12.0",
         "@pothos/plugin-drizzle": "^0.17.0",
         "@pothos/plugin-smart-subscriptions": "^4.1.4",
@@ -29,6 +28,13 @@
       "devDependencies": {
         "@biomejs/biome": "^2.3.14",
         "@graphql-tools/executor-http": "^3.1.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "^0.211.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.211.0",
+        "@opentelemetry/instrumentation": "^0.211.0",
+        "@opentelemetry/instrumentation-http": "^0.211.0",
+        "@opentelemetry/instrumentation-pg": "^0.63.0",
+        "@opentelemetry/sdk-trace-base": "^2.5.0",
+        "@opentelemetry/sdk-trace-node": "^2.5.0",
         "@types/bun": "latest",
         "@types/pg": "^8.16.0",
         "@types/pluralize": "^0.0.33",
@@ -234,11 +240,45 @@
 
     "@js-temporal/polyfill": ["@js-temporal/polyfill@0.5.1", "", { "dependencies": { "jsbi": "^4.3.0" } }, ""],
 
+    "@kubiks/otel-drizzle": ["@kubiks/otel-drizzle@2.1.0", "", { "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <2.0.0", "drizzle-orm": ">=0.28.0" } }, "sha512-9UHb0od3jwa6zTWMyEYPIZcUq5PDaziCmQLMLakSK2zeqy12SFZ3SAGWXJTgEr8valn/Wa+DKVs+Z3aqKQUpvg=="],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.211.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-swFdZq8MCdmdR22jTVGQDhwqDzcI4M10nhjXkLr1EsIzXgZBqm4ZlmmcWsg3TSNf+3mzgOiqveXmBLZuDi2Lgg=="],
+
+    "@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@2.5.0", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-uOXpVX0ZjO7heSVjhheW2XEPrhQAWr2BScDPoZ9UDycl5iuHG+Usyc3AIfG6kZeC1GyLpMInpQ6X5+9n69yOFw=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.5.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ=="],
+
+    "@opentelemetry/exporter-metrics-otlp-http": ["@opentelemetry/exporter-metrics-otlp-http@0.211.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/otlp-exporter-base": "0.211.0", "@opentelemetry/otlp-transformer": "0.211.0", "@opentelemetry/resources": "2.5.0", "@opentelemetry/sdk-metrics": "2.5.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lfHXElPAoDSPpPO59DJdN5FLUnwi1wxluLTWQDayqrSPfWRnluzxRhD+g7rF8wbj1qCz0sdqABl//ug1IZyWvA=="],
+
+    "@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.211.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/otlp-exporter-base": "0.211.0", "@opentelemetry/otlp-transformer": "0.211.0", "@opentelemetry/resources": "2.5.0", "@opentelemetry/sdk-trace-base": "2.5.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-F1Rv3JeMkgS//xdVjbQMrI3+26e5SXC7vXA6trx8SWEA0OUhw4JHB+qeHtH0fJn46eFItrYbL5m8j4qi9Sfaxw=="],
+
+    "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.211.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.211.0", "import-in-the-middle": "^2.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-h0nrZEC/zvI994nhg7EgQ8URIHt0uDTwN90r3qQUdZORS455bbx+YebnGeEuFghUT0HlJSrLF4iHw67f+odY+Q=="],
+
+    "@opentelemetry/instrumentation-http": ["@opentelemetry/instrumentation-http@0.211.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/instrumentation": "0.211.0", "@opentelemetry/semantic-conventions": "^1.29.0", "forwarded-parse": "2.1.2" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-n0IaQ6oVll9PP84SjbOCwDjaJasWRHi6BLsbMLiT6tNj7QbVOkuA5sk/EfZczwI0j5uTKl1awQPivO/ldVtsqA=="],
+
+    "@opentelemetry/instrumentation-pg": ["@opentelemetry/instrumentation-pg@0.63.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.211.0", "@opentelemetry/semantic-conventions": "^1.34.0", "@opentelemetry/sql-common": "^0.41.2", "@types/pg": "8.15.6", "@types/pg-pool": "2.0.7" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-dKm/ODNN3GgIQVlbD6ZPxwRc3kleLf95hrRWXM+l8wYo+vSeXtEpQPT53afEf6VFWDVzJK55VGn8KMLtSve/cg=="],
+
+    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.211.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/otlp-transformer": "0.211.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-bp1+63V8WPV+bRI9EQG6E9YID1LIHYSZVbp7f+44g9tRzCq+rtw/o4fpL5PC31adcUsFiz/oN0MdLISSrZDdrg=="],
+
+    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.211.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.211.0", "@opentelemetry/core": "2.5.0", "@opentelemetry/resources": "2.5.0", "@opentelemetry/sdk-logs": "0.211.0", "@opentelemetry/sdk-metrics": "2.5.0", "@opentelemetry/sdk-trace-base": "2.5.0", "protobufjs": "8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-julhCJ9dXwkOg9svuuYqqjXLhVaUgyUvO2hWbTxwjvLXX2rG3VtAaB0SzxMnGTuoCZizBT7Xqqm2V7+ggrfCXA=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.5.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g=="],
+
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.211.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.211.0", "@opentelemetry/core": "2.5.0", "@opentelemetry/resources": "2.5.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-O5nPwzgg2JHzo59kpQTPUOTzFi0Nv5LxryG27QoXBciX3zWM3z83g+SNOHhiQVYRWFSxoWn1JM2TGD5iNjOwdA=="],
+
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.5.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/resources": "2.5.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-BeJLtU+f5Gf905cJX9vXFQorAr6TAfK3SPvTFqP+scfIpDQEJfRaGJWta7sJgP+m4dNtBf9y3yvBKVAZZtJQVA=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.5.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/resources": "2.5.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-VzRf8LzotASEyNDUxTdaJ9IRJ1/h692WyArDBInf5puLCjxbICD6XkHgpuudis56EndyS7LYFmtTMny6UABNdQ=="],
+
+    "@opentelemetry/sdk-trace-node": ["@opentelemetry/sdk-trace-node@2.5.0", "", { "dependencies": { "@opentelemetry/context-async-hooks": "2.5.0", "@opentelemetry/core": "2.5.0", "@opentelemetry/sdk-trace-base": "2.5.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-O6N/ejzburFm2C84aKNrwJVPpt6HSTSq8T0ZUMq3xT2XmqT4cwxUItcL5UWGThYuq8RTcbH8u1sfj6dmRci0Ow=="],
+
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.39.0", "", {}, "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg=="],
+
+    "@opentelemetry/sql-common": ["@opentelemetry/sql-common@0.41.2", "", { "dependencies": { "@opentelemetry/core": "^2.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0" } }, "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.112.0", "", {}, "sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ=="],
 
@@ -251,6 +291,26 @@
     "@pothos/plugin-tracing": ["@pothos/plugin-tracing@1.1.2", "", { "peerDependencies": { "@pothos/core": "*", "graphql": "^16.10.0" } }, "sha512-2DBLbCqvITS83lSPeuwpNd31fYoPhX6HnoIR5G5p3cQW6cfhEQ1yltJTMq62PrSd91Aadr0HhbT9R0Bhuw6sdQ=="],
 
     "@pothos/tracing-opentelemetry": ["@pothos/tracing-opentelemetry@1.1.3", "", { "peerDependencies": { "@opentelemetry/api": "*", "@opentelemetry/semantic-conventions": "*", "@pothos/core": "*", "@pothos/plugin-tracing": "*", "graphql": "^16.10.0" } }, "sha512-AjcF/hqXejuTw2rQrQweSLXLM8g63gzLPy1IW2hrCjJT1reqCVzcFoYfJeNm2O2QbrA+Ww44RA6BZE6HJCbHjQ=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.4", "", {}, "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
 
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, ""],
 
@@ -304,6 +364,8 @@
 
     "@types/pg": ["@types/pg@8.16.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, ""],
 
+    "@types/pg-pool": ["@types/pg-pool@2.0.7", "", { "dependencies": { "@types/pg": "*" } }, "sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng=="],
+
     "@types/pluralize": ["@types/pluralize@0.0.33", "", {}, ""],
 
     "@types/readable-stream": ["@types/readable-stream@4.0.23", "", { "dependencies": { "@types/node": "*" } }, "sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig=="],
@@ -333,6 +395,8 @@
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
     "acorn": ["acorn@8.15.0", "", { "bin": "bin/acorn" }, ""],
+
+    "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
@@ -365,6 +429,8 @@
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, ""],
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, ""],
+
+    "cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
     "clsx": ["clsx@2.1.1", "", {}, ""],
 
@@ -426,6 +492,8 @@
 
     "fets": ["fets@0.8.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0", "@whatwg-node/cookie-store": "^0.2.0", "@whatwg-node/fetch": "^0.10.0", "@whatwg-node/server": "^0.10.0", "hotscript": "^1.0.11", "json-schema-to-ts": "^3.0.0", "qs": "^6.13.1", "ts-toolbelt": "^9.6.0", "tslib": "^2.3.1" } }, ""],
 
+    "forwarded-parse": ["forwarded-parse@2.1.2", "", {}, "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, ""],
@@ -459,6 +527,8 @@
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
 
     "import-without-cache": ["import-without-cache@0.2.5", "", {}, ""],
 
@@ -524,6 +594,8 @@
 
     "lodash.once": ["lodash.once@4.1.1", "", {}, "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="],
 
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
     "lower-case": ["lower-case@2.0.2", "", { "dependencies": { "tslib": "^2.0.3" } }, ""],
 
     "lru-cache": ["lru-cache@10.4.3", "", {}, ""],
@@ -533,6 +605,8 @@
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, ""],
 
     "meros": ["meros@1.3.2", "", { "peerDependencies": { "@types/node": ">=13" } }, ""],
+
+    "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -584,6 +658,8 @@
 
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 
+    "protobufjs": ["protobufjs@8.0.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-jx6+sE9h/UryaCZhsJWbJtTEy47yXoGNYI4z8ZaRncM0zBKeRqjO2JEcOUYwrYGb1WLhXM1FfMzW3annvFv0rw=="],
+
     "pure-rand": ["pure-rand@6.1.0", "", {}, ""],
 
     "qs": ["qs@6.14.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, ""],
@@ -591,6 +667,8 @@
     "quansync": ["quansync@1.0.0", "", {}, ""],
 
     "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
+
+    "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, ""],
 
@@ -702,6 +780,8 @@
 
     "@jridgewell/trace-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.4", "", {}, ""],
 
+    "@opentelemetry/instrumentation-pg/@types/pg": ["@types/pg@8.15.6", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ=="],
+
     "@whatwg-node/server/@whatwg-node/fetch": ["@whatwg-node/fetch@0.10.12", "", { "dependencies": { "@whatwg-node/node-fetch": "^0.8.2", "urlpattern-polyfill": "^10.0.0" } }, ""],
 
     "fets/@whatwg-node/fetch": ["@whatwg-node/fetch@0.10.8", "", { "dependencies": { "@whatwg-node/node-fetch": "^0.7.21", "urlpattern-polyfill": "^10.0.0" } }, ""],
@@ -721,6 +801,8 @@
     "sofa-api/@whatwg-node/fetch": ["@whatwg-node/fetch@0.10.8", "", { "dependencies": { "@whatwg-node/node-fetch": "^0.7.21", "urlpattern-polyfill": "^10.0.0" } }, ""],
 
     "tsx/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+
+    "@opentelemetry/instrumentation-pg/@types/pg/pg-protocol": ["pg-protocol@1.11.0", "", {}, "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g=="],
 
     "@whatwg-node/server/@whatwg-node/fetch/@whatwg-node/node-fetch": ["@whatwg-node/node-fetch@0.8.2", "", { "dependencies": { "@fastify/busboy": "^3.1.1", "@whatwg-node/disposablestack": "^0.0.6", "@whatwg-node/promise-helpers": "^1.3.2", "tslib": "^2.6.3" } }, ""],
 

--- a/bun.lock
+++ b/bun.lock
@@ -28,13 +28,6 @@
       "devDependencies": {
         "@biomejs/biome": "^2.3.14",
         "@graphql-tools/executor-http": "^3.1.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "^0.211.0",
-        "@opentelemetry/exporter-trace-otlp-http": "^0.211.0",
-        "@opentelemetry/instrumentation": "^0.211.0",
-        "@opentelemetry/instrumentation-http": "^0.211.0",
-        "@opentelemetry/instrumentation-pg": "^0.63.0",
-        "@opentelemetry/sdk-trace-base": "^2.5.0",
-        "@opentelemetry/sdk-trace-node": "^2.5.0",
         "@types/bun": "latest",
         "@types/pg": "^8.16.0",
         "@types/pluralize": "^0.0.33",
@@ -240,45 +233,11 @@
 
     "@js-temporal/polyfill": ["@js-temporal/polyfill@0.5.1", "", { "dependencies": { "jsbi": "^4.3.0" } }, ""],
 
-    "@kubiks/otel-drizzle": ["@kubiks/otel-drizzle@2.1.0", "", { "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <2.0.0", "drizzle-orm": ">=0.28.0" } }, "sha512-9UHb0od3jwa6zTWMyEYPIZcUq5PDaziCmQLMLakSK2zeqy12SFZ3SAGWXJTgEr8valn/Wa+DKVs+Z3aqKQUpvg=="],
-
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
-    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.211.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-swFdZq8MCdmdR22jTVGQDhwqDzcI4M10nhjXkLr1EsIzXgZBqm4ZlmmcWsg3TSNf+3mzgOiqveXmBLZuDi2Lgg=="],
-
-    "@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@2.5.0", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-uOXpVX0ZjO7heSVjhheW2XEPrhQAWr2BScDPoZ9UDycl5iuHG+Usyc3AIfG6kZeC1GyLpMInpQ6X5+9n69yOFw=="],
-
-    "@opentelemetry/core": ["@opentelemetry/core@2.5.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ=="],
-
-    "@opentelemetry/exporter-metrics-otlp-http": ["@opentelemetry/exporter-metrics-otlp-http@0.211.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/otlp-exporter-base": "0.211.0", "@opentelemetry/otlp-transformer": "0.211.0", "@opentelemetry/resources": "2.5.0", "@opentelemetry/sdk-metrics": "2.5.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lfHXElPAoDSPpPO59DJdN5FLUnwi1wxluLTWQDayqrSPfWRnluzxRhD+g7rF8wbj1qCz0sdqABl//ug1IZyWvA=="],
-
-    "@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.211.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/otlp-exporter-base": "0.211.0", "@opentelemetry/otlp-transformer": "0.211.0", "@opentelemetry/resources": "2.5.0", "@opentelemetry/sdk-trace-base": "2.5.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-F1Rv3JeMkgS//xdVjbQMrI3+26e5SXC7vXA6trx8SWEA0OUhw4JHB+qeHtH0fJn46eFItrYbL5m8j4qi9Sfaxw=="],
-
-    "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.211.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.211.0", "import-in-the-middle": "^2.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-h0nrZEC/zvI994nhg7EgQ8URIHt0uDTwN90r3qQUdZORS455bbx+YebnGeEuFghUT0HlJSrLF4iHw67f+odY+Q=="],
-
-    "@opentelemetry/instrumentation-http": ["@opentelemetry/instrumentation-http@0.211.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/instrumentation": "0.211.0", "@opentelemetry/semantic-conventions": "^1.29.0", "forwarded-parse": "2.1.2" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-n0IaQ6oVll9PP84SjbOCwDjaJasWRHi6BLsbMLiT6tNj7QbVOkuA5sk/EfZczwI0j5uTKl1awQPivO/ldVtsqA=="],
-
-    "@opentelemetry/instrumentation-pg": ["@opentelemetry/instrumentation-pg@0.63.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.211.0", "@opentelemetry/semantic-conventions": "^1.34.0", "@opentelemetry/sql-common": "^0.41.2", "@types/pg": "8.15.6", "@types/pg-pool": "2.0.7" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-dKm/ODNN3GgIQVlbD6ZPxwRc3kleLf95hrRWXM+l8wYo+vSeXtEpQPT53afEf6VFWDVzJK55VGn8KMLtSve/cg=="],
-
-    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.211.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/otlp-transformer": "0.211.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-bp1+63V8WPV+bRI9EQG6E9YID1LIHYSZVbp7f+44g9tRzCq+rtw/o4fpL5PC31adcUsFiz/oN0MdLISSrZDdrg=="],
-
-    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.211.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.211.0", "@opentelemetry/core": "2.5.0", "@opentelemetry/resources": "2.5.0", "@opentelemetry/sdk-logs": "0.211.0", "@opentelemetry/sdk-metrics": "2.5.0", "@opentelemetry/sdk-trace-base": "2.5.0", "protobufjs": "8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-julhCJ9dXwkOg9svuuYqqjXLhVaUgyUvO2hWbTxwjvLXX2rG3VtAaB0SzxMnGTuoCZizBT7Xqqm2V7+ggrfCXA=="],
-
-    "@opentelemetry/resources": ["@opentelemetry/resources@2.5.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g=="],
-
-    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.211.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.211.0", "@opentelemetry/core": "2.5.0", "@opentelemetry/resources": "2.5.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-O5nPwzgg2JHzo59kpQTPUOTzFi0Nv5LxryG27QoXBciX3zWM3z83g+SNOHhiQVYRWFSxoWn1JM2TGD5iNjOwdA=="],
-
-    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.5.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/resources": "2.5.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-BeJLtU+f5Gf905cJX9vXFQorAr6TAfK3SPvTFqP+scfIpDQEJfRaGJWta7sJgP+m4dNtBf9y3yvBKVAZZtJQVA=="],
-
-    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.5.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/resources": "2.5.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-VzRf8LzotASEyNDUxTdaJ9IRJ1/h692WyArDBInf5puLCjxbICD6XkHgpuudis56EndyS7LYFmtTMny6UABNdQ=="],
-
-    "@opentelemetry/sdk-trace-node": ["@opentelemetry/sdk-trace-node@2.5.0", "", { "dependencies": { "@opentelemetry/context-async-hooks": "2.5.0", "@opentelemetry/core": "2.5.0", "@opentelemetry/sdk-trace-base": "2.5.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-O6N/ejzburFm2C84aKNrwJVPpt6HSTSq8T0ZUMq3xT2XmqT4cwxUItcL5UWGThYuq8RTcbH8u1sfj6dmRci0Ow=="],
-
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.39.0", "", {}, "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg=="],
-
-    "@opentelemetry/sql-common": ["@opentelemetry/sql-common@0.41.2", "", { "dependencies": { "@opentelemetry/core": "^2.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0" } }, "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.112.0", "", {}, "sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ=="],
 
@@ -291,26 +250,6 @@
     "@pothos/plugin-tracing": ["@pothos/plugin-tracing@1.1.2", "", { "peerDependencies": { "@pothos/core": "*", "graphql": "^16.10.0" } }, "sha512-2DBLbCqvITS83lSPeuwpNd31fYoPhX6HnoIR5G5p3cQW6cfhEQ1yltJTMq62PrSd91Aadr0HhbT9R0Bhuw6sdQ=="],
 
     "@pothos/tracing-opentelemetry": ["@pothos/tracing-opentelemetry@1.1.3", "", { "peerDependencies": { "@opentelemetry/api": "*", "@opentelemetry/semantic-conventions": "*", "@pothos/core": "*", "@pothos/plugin-tracing": "*", "graphql": "^16.10.0" } }, "sha512-AjcF/hqXejuTw2rQrQweSLXLM8g63gzLPy1IW2hrCjJT1reqCVzcFoYfJeNm2O2QbrA+Ww44RA6BZE6HJCbHjQ=="],
-
-    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
-
-    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
-
-    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.4", "", {}, "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="],
-
-    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
-
-    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
-
-    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
-
-    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
-
-    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
-
-    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
-
-    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
 
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, ""],
 
@@ -364,8 +303,6 @@
 
     "@types/pg": ["@types/pg@8.16.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, ""],
 
-    "@types/pg-pool": ["@types/pg-pool@2.0.7", "", { "dependencies": { "@types/pg": "*" } }, "sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng=="],
-
     "@types/pluralize": ["@types/pluralize@0.0.33", "", {}, ""],
 
     "@types/readable-stream": ["@types/readable-stream@4.0.23", "", { "dependencies": { "@types/node": "*" } }, "sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig=="],
@@ -395,8 +332,6 @@
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
     "acorn": ["acorn@8.15.0", "", { "bin": "bin/acorn" }, ""],
-
-    "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
@@ -429,8 +364,6 @@
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, ""],
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, ""],
-
-    "cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
     "clsx": ["clsx@2.1.1", "", {}, ""],
 
@@ -492,8 +425,6 @@
 
     "fets": ["fets@0.8.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0", "@whatwg-node/cookie-store": "^0.2.0", "@whatwg-node/fetch": "^0.10.0", "@whatwg-node/server": "^0.10.0", "hotscript": "^1.0.11", "json-schema-to-ts": "^3.0.0", "qs": "^6.13.1", "ts-toolbelt": "^9.6.0", "tslib": "^2.3.1" } }, ""],
 
-    "forwarded-parse": ["forwarded-parse@2.1.2", "", {}, "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw=="],
-
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, ""],
@@ -527,8 +458,6 @@
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
-
-    "import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
 
     "import-without-cache": ["import-without-cache@0.2.5", "", {}, ""],
 
@@ -594,8 +523,6 @@
 
     "lodash.once": ["lodash.once@4.1.1", "", {}, "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="],
 
-    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
-
     "lower-case": ["lower-case@2.0.2", "", { "dependencies": { "tslib": "^2.0.3" } }, ""],
 
     "lru-cache": ["lru-cache@10.4.3", "", {}, ""],
@@ -605,8 +532,6 @@
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, ""],
 
     "meros": ["meros@1.3.2", "", { "peerDependencies": { "@types/node": ">=13" } }, ""],
-
-    "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -658,8 +583,6 @@
 
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 
-    "protobufjs": ["protobufjs@8.0.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-jx6+sE9h/UryaCZhsJWbJtTEy47yXoGNYI4z8ZaRncM0zBKeRqjO2JEcOUYwrYGb1WLhXM1FfMzW3annvFv0rw=="],
-
     "pure-rand": ["pure-rand@6.1.0", "", {}, ""],
 
     "qs": ["qs@6.14.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, ""],
@@ -667,8 +590,6 @@
     "quansync": ["quansync@1.0.0", "", {}, ""],
 
     "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
-
-    "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, ""],
 
@@ -780,8 +701,6 @@
 
     "@jridgewell/trace-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.4", "", {}, ""],
 
-    "@opentelemetry/instrumentation-pg/@types/pg": ["@types/pg@8.15.6", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ=="],
-
     "@whatwg-node/server/@whatwg-node/fetch": ["@whatwg-node/fetch@0.10.12", "", { "dependencies": { "@whatwg-node/node-fetch": "^0.8.2", "urlpattern-polyfill": "^10.0.0" } }, ""],
 
     "fets/@whatwg-node/fetch": ["@whatwg-node/fetch@0.10.8", "", { "dependencies": { "@whatwg-node/node-fetch": "^0.7.21", "urlpattern-polyfill": "^10.0.0" } }, ""],
@@ -801,8 +720,6 @@
     "sofa-api/@whatwg-node/fetch": ["@whatwg-node/fetch@0.10.8", "", { "dependencies": { "@whatwg-node/node-fetch": "^0.7.21", "urlpattern-polyfill": "^10.0.0" } }, ""],
 
     "tsx/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
-
-    "@opentelemetry/instrumentation-pg/@types/pg/pg-protocol": ["pg-protocol@1.11.0", "", {}, "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g=="],
 
     "@whatwg-node/server/@whatwg-node/fetch/@whatwg-node/node-fetch": ["@whatwg-node/node-fetch@0.8.2", "", { "dependencies": { "@fastify/busboy": "^3.1.1", "@whatwg-node/disposablestack": "^0.0.6", "@whatwg-node/promise-helpers": "^1.3.2", "tslib": "^2.6.3" } }, ""],
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,15 +1,18 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@m1212e/rumble",
       "dependencies": {
         "@escape.tech/graphql-armor": "^3.2.0",
         "@graphql-yoga/plugin-disable-introspection": "^2.19.0",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0",
         "@pothos/core": "^4.12.0",
         "@pothos/plugin-drizzle": "^0.17.0",
         "@pothos/plugin-smart-subscriptions": "^4.1.4",
+        "@pothos/plugin-tracing": "^1.1.2",
+        "@pothos/tracing-opentelemetry": "^1.1.3",
         "@urql/core": "^6.0.1",
         "@urql/exchange-graphcache": "^9.0.0",
         "@urql/introspection": "^1.2.1",
@@ -20,7 +23,7 @@
         "graphql-yoga": "^5.18.0",
         "pluralize": "^8.0.0",
         "sofa-api": "^0.18.8",
-        "svelte": "^5.49.2",
+        "svelte": "^5.50.0",
         "wonka": "^6.3.5",
       },
       "devDependencies": {
@@ -233,6 +236,10 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.39.0", "", {}, "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg=="],
+
     "@oxc-project/types": ["@oxc-project/types@0.112.0", "", {}, "sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ=="],
 
     "@pothos/core": ["@pothos/core@4.12.0", "", { "peerDependencies": { "graphql": "^16.10.0" } }, ""],
@@ -240,6 +247,10 @@
     "@pothos/plugin-drizzle": ["@pothos/plugin-drizzle@0.17.0", "", { "peerDependencies": { "@pothos/core": "*", "drizzle-orm": ">=1.0.0-beta.2", "graphql": "^16.10.0" } }, "sha512-nV2KYqnRLjgK6DTUq22SXDtjeeJ/RGJ2VF8U0uTSGfwpmI93LcDkIFJ4hV1Jd3agoNhM3QLY25eZPHczY5XRcA=="],
 
     "@pothos/plugin-smart-subscriptions": ["@pothos/plugin-smart-subscriptions@4.1.4", "", { "peerDependencies": { "@pothos/core": "*", "graphql": "^16.10.0" } }, ""],
+
+    "@pothos/plugin-tracing": ["@pothos/plugin-tracing@1.1.2", "", { "peerDependencies": { "@pothos/core": "*", "graphql": "^16.10.0" } }, "sha512-2DBLbCqvITS83lSPeuwpNd31fYoPhX6HnoIR5G5p3cQW6cfhEQ1yltJTMq62PrSd91Aadr0HhbT9R0Bhuw6sdQ=="],
+
+    "@pothos/tracing-opentelemetry": ["@pothos/tracing-opentelemetry@1.1.3", "", { "peerDependencies": { "@opentelemetry/api": "*", "@opentelemetry/semantic-conventions": "*", "@pothos/core": "*", "@pothos/plugin-tracing": "*", "graphql": "^16.10.0" } }, "sha512-AjcF/hqXejuTw2rQrQweSLXLM8g63gzLPy1IW2hrCjJT1reqCVzcFoYfJeNm2O2QbrA+Ww44RA6BZE6HJCbHjQ=="],
 
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, ""],
 
@@ -613,7 +624,7 @@
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
-    "svelte": ["svelte@5.49.2", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.6.2", "esm-env": "^1.2.1", "esrap": "^2.2.2", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-PYLwnngYzyhKzqDlGVlCH4z+NVI8mC0/bTv15vw25CcdOhxENsOHIbQ36oj5DIf3oBazM+STbCAvaskpxtBmWA=="],
+    "svelte": ["svelte@5.50.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.6.2", "esm-env": "^1.2.1", "esrap": "^2.2.2", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-FR9kTLmX5i0oyeQ5j/+w8DuagIkQ7MWMuPpPVioW2zx9Dw77q+1ufLzF1IqNtcTXPRnIIio4PlasliVn43OnbQ=="],
 
     "tarn": ["tarn@3.0.2", "", {}, "sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
         "@escape.tech/graphql-armor": "^3.2.0",
         "@graphql-yoga/plugin-disable-introspection": "^2.19.0",
         "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0",
         "@pothos/core": "^4.12.0",
         "@pothos/plugin-drizzle": "^0.17.0",
         "@pothos/plugin-smart-subscriptions": "^4.1.4",

--- a/lib/abilityBuilder.ts
+++ b/lib/abilityBuilder.ts
@@ -1,4 +1,4 @@
-import { type Span, trace } from "@opentelemetry/api";
+import type { Span } from "@opentelemetry/api";
 import { relationsFilterToSQL } from "drizzle-orm";
 import { debounce } from "es-toolkit";
 import { lazy } from "./helpers/lazy";
@@ -556,9 +556,7 @@ export const createAbilityBuilder = <
                     // in case we have a wildcard ability, skip the rest and return no filters at all
                     if (filters === "unrestricted") {
                       span?.setAttribute("abilities.status", "unrestricted");
-                      const r = transformToResponse();
-                      span?.end();
-                      return r;
+                      return transformToResponse();
                     }
 
                     // if nothing has been allowed, block everything
@@ -571,9 +569,7 @@ export const createAbilityBuilder = <
                         tableName.toString(),
                         action,
                       );
-                      const r = transformToResponse(blockEverythingFilter);
-                      span?.end();
-                      return r;
+                      return transformToResponse(blockEverythingFilter);
                     }
 
                     // run all dynamic filters
@@ -590,9 +586,7 @@ export const createAbilityBuilder = <
                       const result = func(userContext);
                       // if one of the dynamic filters returns "allow", we want to allow everything
                       if (result === "allow") {
-                        const r = transformToResponse();
-                        span?.end();
-                        return r;
+                        return transformToResponse();
                       }
                       // if nothing is returned, nothing is allowed by this filter
                       if (result === undefined) continue;
@@ -627,9 +621,7 @@ export const createAbilityBuilder = <
                         "blocked_everything",
                       );
 
-                      const r = transformToResponse(blockEverythingFilter);
-                      span?.end();
-                      return r;
+                      return transformToResponse(blockEverythingFilter);
                     }
 
                     const mergedFilters =
@@ -640,15 +632,19 @@ export const createAbilityBuilder = <
                           }, {});
 
                     span?.setAttribute("abilities.status", "applied");
-                    const r = transformToResponse(mergedFilters as any);
-                    span?.end();
-                    return r;
+                    return transformToResponse(mergedFilters as any);
                   };
 
                   if (otel?.tracer) {
                     return otel.tracer.startActiveSpan(
                       `prepare_query_abilities_${action}`,
-                      assembleAbilities,
+                      (span) => {
+                        try {
+                          return assembleAbilities(span);
+                        } finally {
+                          span.end();
+                        }
+                      },
                     );
                   } else {
                     return assembleAbilities();

--- a/lib/abilityBuilder.ts
+++ b/lib/abilityBuilder.ts
@@ -1,3 +1,4 @@
+import { type Span, trace } from "@opentelemetry/api";
 import { relationsFilterToSQL } from "drizzle-orm";
 import { debounce } from "es-toolkit";
 import { lazy } from "./helpers/lazy";
@@ -115,6 +116,7 @@ export const createAbilityBuilder = <
   db,
   actions,
   defaultLimit,
+  otel,
 }: RumbleInput<UserContext, DB, RequestEvent, Action, PothosConfig>) => {
   type TableNames = keyof DrizzleQueryFunction<DB>;
 
@@ -548,59 +550,109 @@ export const createAbilityBuilder = <
             withContext: (userContext: UserContext) => {
               return {
                 filter: (action: Action) => {
-                  const filters = queryFilters.get(action);
+                  const assembleAbilities = (span?: Span) => {
+                    const filters = queryFilters.get(action);
 
-                  // in case we have a wildcard ability, skip the rest and return no filters at all
-                  if (filters === "unrestricted") {
-                    return transformToResponse();
-                  }
-
-                  // if nothing has been allowed, block everything
-                  if (!filters) {
-                    nothingRegisteredWarningLogger(
-                      tableName.toString(),
-                      action,
-                    );
-                    return transformToResponse(blockEverythingFilter);
-                  }
-
-                  // run all dynamic filters
-                  const dynamicResults = new Array<
-                    DrizzleQueryFunctionInput<DB, TableName>
-                  >(dynamicQueryFilters[action].length);
-                  let filtersReturned = 0;
-                  for (let i = 0; i < dynamicQueryFilters[action].length; i++) {
-                    const func = dynamicQueryFilters[action][i];
-                    const result = func(userContext);
-                    // if one of the dynamic filters returns "allow", we want to allow everything
-                    if (result === "allow") {
-                      return transformToResponse();
+                    // in case we have a wildcard ability, skip the rest and return no filters at all
+                    if (filters === "unrestricted") {
+                      span?.setAttribute("abilities.status", "unrestricted");
+                      const r = transformToResponse();
+                      span?.end();
+                      return r;
                     }
-                    // if nothing is returned, nothing is allowed by this filter
-                    if (result === undefined) continue;
 
-                    dynamicResults[filtersReturned++] = result;
+                    // if nothing has been allowed, block everything
+                    if (!filters) {
+                      span?.setAttribute(
+                        "abilities.status",
+                        "blocked_everything",
+                      );
+                      nothingRegisteredWarningLogger(
+                        tableName.toString(),
+                        action,
+                      );
+                      const r = transformToResponse(blockEverythingFilter);
+                      span?.end();
+                      return r;
+                    }
+
+                    // run all dynamic filters
+                    const dynamicResults = new Array<
+                      DrizzleQueryFunctionInput<DB, TableName>
+                    >(dynamicQueryFilters[action].length);
+                    let filtersReturned = 0;
+                    for (
+                      let i = 0;
+                      i < dynamicQueryFilters[action].length;
+                      i++
+                    ) {
+                      const func = dynamicQueryFilters[action][i];
+                      const result = func(userContext);
+                      // if one of the dynamic filters returns "allow", we want to allow everything
+                      if (result === "allow") {
+                        const r = transformToResponse();
+                        span?.end();
+                        return r;
+                      }
+                      // if nothing is returned, nothing is allowed by this filter
+                      if (result === undefined) continue;
+
+                      dynamicResults[filtersReturned++] = result;
+                    }
+                    dynamicResults.length = filtersReturned;
+
+                    span?.setAttribute(
+                      "abilities.dynamic",
+                      dynamicResults.length,
+                    );
+                    span?.setAttribute(
+                      "abilities.static",
+                      simpleQueryFilters[action].length,
+                    );
+
+                    const allQueryFilters = [
+                      ...simpleQueryFilters[action],
+                      ...dynamicResults,
+                    ];
+
+                    span?.setAttribute(
+                      "abilities.total",
+                      allQueryFilters.length,
+                    );
+
+                    // if we don't have any permitted filters then block everything
+                    if (allQueryFilters.length === 0) {
+                      span?.setAttribute(
+                        "abilities.status",
+                        "blocked_everything",
+                      );
+
+                      const r = transformToResponse(blockEverythingFilter);
+                      span?.end();
+                      return r;
+                    }
+
+                    const mergedFilters =
+                      allQueryFilters.length === 1
+                        ? allQueryFilters[0]
+                        : allQueryFilters.reduce((a, b) => {
+                            return mergeFilters(a, b);
+                          }, {});
+
+                    span?.setAttribute("abilities.status", "applied");
+                    const r = transformToResponse(mergedFilters as any);
+                    span?.end();
+                    return r;
+                  };
+
+                  if (otel?.tracer) {
+                    return otel.tracer.startActiveSpan(
+                      `prepare_query_abilities_${action}`,
+                      assembleAbilities,
+                    );
+                  } else {
+                    return assembleAbilities();
                   }
-                  dynamicResults.length = filtersReturned;
-
-                  const allQueryFilters = [
-                    ...simpleQueryFilters[action],
-                    ...dynamicResults,
-                  ];
-
-                  // if we don't have any permitted filters then block everything
-                  if (allQueryFilters.length === 0) {
-                    return transformToResponse(blockEverythingFilter);
-                  }
-
-                  const mergedFilters =
-                    allQueryFilters.length === 1
-                      ? allQueryFilters[0]
-                      : allQueryFilters.reduce((a, b) => {
-                          return mergeFilters(a, b);
-                        }, {});
-
-                  return transformToResponse(mergedFilters as any);
                 },
               };
             },

--- a/lib/rumble.ts
+++ b/lib/rumble.ts
@@ -334,15 +334,16 @@ export const db = drizzle(
     createYoga,
     /**
      * Creates a sofa instance to offer a REST API.
-    ```ts
-    import express from 'express';
-
-    const app = express();
-    const sofa = createSofa(...);
-
-    app.use('/api', useSofa({ schema }));
-    ```
-    * https://the-guild.dev/graphql/sofa-api/docs#usage
+     *
+     * ```ts
+     * import express from "express";
+     *
+     * const app = express();
+     * const sofa = createSofa(...);
+     *
+     * app.use("/api", useSofa({ schema }));
+     * ```
+     * https://the-guild.dev/graphql/sofa-api/docs#usage
      */
     createSofa,
     /**

--- a/lib/rumble.ts
+++ b/lib/rumble.ts
@@ -241,7 +241,7 @@ export const db = drizzle(
                     {
                       attributes: {
                         [AttributeNames.OPERATION_NAME]:
-                          options.operationName ?? undefined,
+                          options.operationName ?? "anonymous",
                         // TODO
                         // [AttributeNames.SOURCE]: print(options.document),
                       },
@@ -317,20 +317,19 @@ export const db = drizzle(
      */
     schemaBuilder,
     /**
-       * Creates the native yoga instance. Can be used to run an actual HTTP server.
-       *
-       * @example
-       *
-       * ```ts
+     * Creates the native yoga instance. Can be used to run an actual HTTP server.
      *
-        import { createServer } from "node:http";
-    * const server = createServer(createYoga());
-    server.listen(3000, () => {
-            console.info("Visit http://localhost:3000/graphql");
-      });
-      * ```
+     * @example
+     *
+     * ```ts
+     * import { createServer } from "node:http";
+     * const server = createServer(createYoga());
+     * server.listen(3000, () => {
+     *   console.info("Visit http://localhost:3000/graphql");
+     * });
+     * ```
      * https://the-guild.dev/graphql/yoga-server/docs#server
-       */
+     */
     createYoga,
     /**
      * Creates a sofa instance to offer a REST API.

--- a/lib/rumble.ts
+++ b/lib/rumble.ts
@@ -1,8 +1,10 @@
 import { EnvelopArmorPlugin } from "@escape.tech/graphql-armor";
 import { useDisableIntrospection } from "@graphql-yoga/plugin-disable-introspection";
+import { AttributeNames, SpanNames } from "@pothos/tracing-opentelemetry";
 import { merge } from "es-toolkit";
 import {
   createYoga as nativeCreateYoga,
+  type Plugin,
   type YogaServerOptions,
 } from "graphql-yoga";
 import { useSofa } from "sofa-api";
@@ -61,7 +63,7 @@ export const db = drizzle(
   "postgres://postgres:postgres@localhost:5432/postgres",
   {
     relations, // <--- add this line
-    schema,   
+    schema,
   },
 );
 
@@ -230,6 +232,37 @@ export const db = drizzle(
         ...(enableApiDocs
           ? []
           : [useDisableIntrospection(), EnvelopArmorPlugin()]),
+        rumbleInput.otel?.tracer
+          ? ({
+              onExecute: ({ setExecuteFn, executeFn }) => {
+                setExecuteFn((options) =>
+                  rumbleInput.otel!.tracer.startActiveSpan(
+                    SpanNames.EXECUTE,
+                    {
+                      attributes: {
+                        [AttributeNames.OPERATION_NAME]:
+                          options.operationName ?? undefined,
+                        // TODO
+                        // [AttributeNames.SOURCE]: print(options.document),
+                      },
+                    },
+                    async (span) => {
+                      try {
+                        const result = await executeFn(options);
+
+                        return result;
+                      } catch (error) {
+                        span.recordException(error as Error);
+                        throw error;
+                      } finally {
+                        span.end();
+                      }
+                    },
+                  ),
+                );
+              },
+            } as Plugin)
+          : false,
       ].filter(Boolean),
       schema: builtSchema(),
       context,
@@ -264,18 +297,18 @@ export const db = drizzle(
   return {
     /**
        * The ability builder. Use it to declare whats allowed for each entity in your DB.
-       * 
+       *
        * @example
-       * 
+       *
        * ```ts
        * // users can edit themselves
        abilityBuilder.users
          .allow(["read", "update", "delete"])
          .when(({ userId }) => ({ where: eq(schema.users.id, userId) }));
-       
+
        // everyone can read posts
        abilityBuilder.posts.allow("read");
-       * 
+       *
        * ```
        */
     abilityBuilder,
@@ -285,32 +318,32 @@ export const db = drizzle(
     schemaBuilder,
     /**
        * Creates the native yoga instance. Can be used to run an actual HTTP server.
-       * 
+       *
        * @example
-       * 
+       *
        * ```ts
-	   * 
+     *
         import { createServer } from "node:http";
-		* const server = createServer(createYoga());
-		server.listen(3000, () => {
+    * const server = createServer(createYoga());
+    server.listen(3000, () => {
             console.info("Visit http://localhost:3000/graphql");
-			});
-			* ```
-	   * https://the-guild.dev/graphql/yoga-server/docs#server
+      });
+      * ```
+     * https://the-guild.dev/graphql/yoga-server/docs#server
        */
     createYoga,
     /**
-		 * Creates a sofa instance to offer a REST API.
-		```ts
-		import express from 'express';
-		
-		const app = express();
-		const sofa = createSofa(...);
-		
-		app.use('/api', useSofa({ schema }));
-		```
-		* https://the-guild.dev/graphql/sofa-api/docs#usage
-		 */
+     * Creates a sofa instance to offer a REST API.
+    ```ts
+    import express from 'express';
+
+    const app = express();
+    const sofa = createSofa(...);
+
+    app.use('/api', useSofa({ schema }));
+    ```
+    * https://the-guild.dev/graphql/sofa-api/docs#usage
+     */
     createSofa,
     /**
      * A function for creating default objects for your schema

--- a/lib/runtimeFiltersPlugin/pluginTypes.d.ts
+++ b/lib/runtimeFiltersPlugin/pluginTypes.d.ts
@@ -1,4 +1,5 @@
 import type { SchemaTypes } from "@pothos/core";
+import type { Tracer } from "@opentelemetry/api";
 import type { pluginName } from "./filterTypes";
 import type {
   applyFiltersKey,
@@ -11,10 +12,9 @@ declare global {
       [pluginName]: RuntimeFiltersPlugin<Types>;
     }
 
-    // export interface SchemaBuilderOptions<Types extends SchemaTypes> {
-    //   optionInRootOfConfig?: boolean;
-    //   nestedOptionsObject?: ExamplePluginOptions;
-    // }
+    export interface SchemaBuilderOptions<Types extends SchemaTypes> {
+      otelTracer?: Tracer;
+    }
 
     // export interface BuildSchemaOptions<Types extends SchemaTypes> {
     //   customBuildTimeOptions?: boolean;

--- a/lib/runtimeFiltersPlugin/runtimeFiltersPlugin.ts
+++ b/lib/runtimeFiltersPlugin/runtimeFiltersPlugin.ts
@@ -1,6 +1,8 @@
+import type { Span, Tracer } from "@opentelemetry/api";
 import SchemaBuilder, {
   BasePlugin,
   type PothosOutputFieldConfig,
+  type PothosTypeConfig,
   type SchemaTypes,
 } from "@pothos/core";
 import type { GraphQLFieldResolver } from "graphql";
@@ -12,45 +14,70 @@ export const applyFiltersKey = "applyFilters";
 export class RuntimeFiltersPlugin<
   Types extends SchemaTypes,
 > extends BasePlugin<Types> {
+  private tracer?: Tracer;
+  override onTypeConfig(typeConfig: PothosTypeConfig) {
+    this.tracer = this.builder.options.otelTracer;
+    return typeConfig;
+  }
+
   override wrapResolve(
     resolver: GraphQLFieldResolver<unknown, Types["Context"], object>,
     fieldConfig: PothosOutputFieldConfig<Types>,
   ): GraphQLFieldResolver<unknown, Types["Context"], object> {
     return async (parent, args, context, info) => {
-      //TODO: https://github.com/hayes/pothos/discussions/1431#discussioncomment-12974130
-      let filters: ApplyFiltersField<Types["Context"], any> | undefined;
-      const fieldType = fieldConfig?.type as any;
+      const runFilters = async (span?: Span) => {
+        //TODO: https://github.com/hayes/pothos/discussions/1431#discussioncomment-12974130
+        let filters: ApplyFiltersField<Types["Context"], any> | undefined;
+        const fieldType = fieldConfig?.type as any;
 
-      if (fieldType.kind === "List") {
-        filters =
-          fieldType.type?.ref.currentConfig.pothosOptions[applyFiltersKey];
-      } else if (fieldType.kind === "Object") {
-        filters = fieldType.ref.currentConfig.pothosOptions[applyFiltersKey];
+        if (fieldType.kind === "List") {
+          filters =
+            fieldType.type?.ref.currentConfig.pothosOptions[applyFiltersKey];
+        } else if (fieldType.kind === "Object") {
+          filters = fieldType.ref.currentConfig.pothosOptions[applyFiltersKey];
+        }
+
+        if (!filters || !Array.isArray(filters) || filters.length === 0) {
+          span?.setAttribute("filters.status", "unrestricted");
+          span?.end();
+          // if no filter should be applied, just continue
+          return resolver(parent, args, context, info);
+        }
+
+        const resolved = await resolver(parent, args, context, info);
+        const allResolvedValues = Array.isArray(resolved)
+          ? resolved
+          : [resolved];
+        const allFilters = Array.isArray(filters) ? filters : [filters];
+        span?.setAttribute("filters.total", allFilters.length);
+
+        const allowed = await applyFilters({
+          filters: allFilters,
+          entities: allResolvedValues,
+          context,
+        });
+        span?.setAttribute("filters.allowed", allowed.length);
+
+        // if the original value was an array, return an array
+        if (Array.isArray(resolved)) {
+          span?.end();
+          return allowed;
+        }
+
+        span?.end();
+        // if the original value was a single value, return the first allowed
+        // or null if not allowed
+        return allowed[0] ?? null;
+      };
+
+      if (this.tracer) {
+        return this.tracer.startActiveSpan(
+          `apply_filters_${fieldConfig.name}`,
+          runFilters,
+        );
+      } else {
+        return runFilters();
       }
-
-      if (!filters || !Array.isArray(filters) || filters.length === 0) {
-        // if no filter should be applied, just continue
-        return resolver(parent, args, context, info);
-      }
-
-      const resolved = await resolver(parent, args, context, info);
-      const allResolvedValues = Array.isArray(resolved) ? resolved : [resolved];
-      const allFilters = Array.isArray(filters) ? filters : [filters];
-
-      const allowed = await applyFilters({
-        filters: allFilters,
-        entities: allResolvedValues,
-        context,
-      });
-
-      // if the original value was an array, return an array
-      if (Array.isArray(resolved)) {
-        return allowed;
-      }
-
-      // if the original value was a single value, return the first allowed
-      // or null if not allowed
-      return allowed[0] ?? null;
     };
   }
 }

--- a/lib/runtimeFiltersPlugin/runtimeFiltersPlugin.ts
+++ b/lib/runtimeFiltersPlugin/runtimeFiltersPlugin.ts
@@ -39,7 +39,6 @@ export class RuntimeFiltersPlugin<
 
         if (!filters || !Array.isArray(filters) || filters.length === 0) {
           span?.setAttribute("filters.status", "unrestricted");
-          span?.end();
           // if no filter should be applied, just continue
           return resolver(parent, args, context, info);
         }
@@ -60,11 +59,9 @@ export class RuntimeFiltersPlugin<
 
         // if the original value was an array, return an array
         if (Array.isArray(resolved)) {
-          span?.end();
           return allowed;
         }
 
-        span?.end();
         // if the original value was a single value, return the first allowed
         // or null if not allowed
         return allowed[0] ?? null;
@@ -73,7 +70,13 @@ export class RuntimeFiltersPlugin<
       if (this.tracer) {
         return this.tracer.startActiveSpan(
           `apply_filters_${fieldConfig.name}`,
-          runFilters,
+          (span) => {
+            try {
+              return runFilters();
+            } finally {
+              span.end();
+            }
+          },
         );
       } else {
         return runFilters();

--- a/lib/runtimeFiltersPlugin/runtimeFiltersPlugin.ts
+++ b/lib/runtimeFiltersPlugin/runtimeFiltersPlugin.ts
@@ -70,9 +70,9 @@ export class RuntimeFiltersPlugin<
       if (this.tracer) {
         return this.tracer.startActiveSpan(
           `apply_filters_${fieldConfig.name}`,
-          (span) => {
+          async (span) => {
             try {
-              return runFilters();
+              return await runFilters();
             } finally {
               span.end();
             }

--- a/lib/schemaBuilder.ts
+++ b/lib/schemaBuilder.ts
@@ -104,6 +104,7 @@ export const createSchemaBuilder = <
         ? (resolver, options) => createSpan(resolver, options)
         : (resolver) => resolver,
     },
+    otelTracer: otel?.tracer,
   });
 
   schemaBuilder.addScalarType("JSON", JSONResolver);

--- a/lib/schemaBuilder.ts
+++ b/lib/schemaBuilder.ts
@@ -3,6 +3,8 @@ import DrizzlePlugin from "@pothos/plugin-drizzle";
 import SmartSubscriptionsPlugin, {
   subscribeOptionsFromIterator,
 } from "@pothos/plugin-smart-subscriptions";
+import TracingPlugin, { isRootField } from "@pothos/plugin-tracing";
+import { createOpenTelemetryWrapper } from "@pothos/tracing-opentelemetry";
 import {
   DateResolver,
   DateTimeISOResolver,
@@ -35,9 +37,14 @@ export const createSchemaBuilder = <
   disableDefaultObjects,
   pubsub,
   pothosConfig,
+  otel,
 }: RumbleInput<UserContext, DB, RequestEvent, Action, PothosConfig> & {
   pubsub: ReturnType<typeof createPubSub>;
 }) => {
+  const createSpan = otel?.tracer
+    ? createOpenTelemetryWrapper(otel.tracer, otel.options)
+    : undefined;
+
   registerRuntimeFiltersPlugin();
   const schemaBuilder = new SchemaBuilder<{
     Context: ContextType<UserContext, DB, RequestEvent, Action, PothosConfig>;
@@ -69,6 +76,7 @@ export const createSchemaBuilder = <
       pluginName,
       DrizzlePlugin,
       SmartSubscriptionsPlugin,
+      TracingPlugin,
       ...(pothosConfig?.plugins ?? []),
     ],
     drizzle: {
@@ -90,6 +98,12 @@ export const createSchemaBuilder = <
       }),
     },
     defaultFieldNullability: false,
+    tracing: {
+      default: otel?.tracer ? (config) => isRootField(config) : () => false,
+      wrap: createSpan
+        ? (resolver, options) => createSpan(resolver, options)
+        : (resolver) => resolver,
+    },
   });
 
   schemaBuilder.addScalarType("JSON", JSONResolver);

--- a/lib/types/rumbleInput.ts
+++ b/lib/types/rumbleInput.ts
@@ -1,4 +1,6 @@
+import type { Tracer } from "@opentelemetry/api";
 import type SchemaBuilder from "@pothos/core";
+import type { TracingWrapperOptions } from "@pothos/tracing-opentelemetry";
 import type { createPubSub } from "graphql-yoga";
 import type { DrizzleInstance } from "./drizzleInstanceType";
 
@@ -78,4 +80,17 @@ export type RumbleInput<
         cpu_operator_cost?: number;
       }
     | undefined;
+  /**
+   * rumble can setup otel tracing if you want to. This will provide details of execution time and outcome to the provided tracer. See https://pothos-graphql.dev/docs/plugins/tracing#install for more information.
+   */
+  otel?: {
+    /**
+     * The tracer to use
+     */
+    tracer: Tracer;
+    /**
+     * You can pass options to the tracing wrapper
+     */
+    options?: TracingWrapperOptions<unknown>;
+  };
 };

--- a/lib/types/rumbleInput.ts
+++ b/lib/types/rumbleInput.ts
@@ -81,7 +81,7 @@ export type RumbleInput<
       }
     | undefined;
   /**
-   * rumble can setup otel tracing if you want to. This will provide details of execution time and outcome to the provided tracer. See https://pothos-graphql.dev/docs/plugins/tracing#install for more information.
+   * rumble can set up otel tracing if you want to. This will provide details of execution time and outcome to the provided tracer. See https://pothos-graphql.dev/docs/plugins/tracing#install for more information.
    */
   otel?: {
     /**

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@escape.tech/graphql-armor": "^3.2.0",
     "@graphql-yoga/plugin-disable-introspection": "^2.19.0",
     "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/semantic-conventions": "^1.39.0",
     "@pothos/core": "^4.12.0",
     "@pothos/plugin-drizzle": "^0.17.0",
     "@pothos/plugin-smart-subscriptions": "^4.1.4",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,13 @@
   "dependencies": {
     "@escape.tech/graphql-armor": "^3.2.0",
     "@graphql-yoga/plugin-disable-introspection": "^2.19.0",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/semantic-conventions": "^1.39.0",
     "@pothos/core": "^4.12.0",
     "@pothos/plugin-drizzle": "^0.17.0",
     "@pothos/plugin-smart-subscriptions": "^4.1.4",
+    "@pothos/plugin-tracing": "^1.1.2",
+    "@pothos/tracing-opentelemetry": "^1.1.3",
     "@urql/core": "^6.0.1",
     "@urql/exchange-graphcache": "^9.0.0",
     "@urql/introspection": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@escape.tech/graphql-armor": "^3.2.0",
     "@graphql-yoga/plugin-disable-introspection": "^2.19.0",
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/semantic-conventions": "^1.39.0",
     "@pothos/core": "^4.12.0",
     "@pothos/plugin-drizzle": "^0.17.0",
     "@pothos/plugin-smart-subscriptions": "^4.1.4",


### PR DESCRIPTION
This pull request adds OpenTelemetry tracing support throughout the codebase, enabling detailed instrumentation for ability building, filter application, and GraphQL execution. The changes introduce new dependencies, update configuration types, and integrate tracing into core logic for enhanced observability.

**Tracing integration:**

* Added OpenTelemetry tracing support to `createAbilityBuilder`, instrumenting ability filter logic and recording span attributes for unrestricted, blocked, dynamic, and applied abilities. (`lib/abilityBuilder.ts`) [[1]](diffhunk://#diff-f897effc1c790267dec1c1b968ac6255226e2776d6d6faf458a31d3789389b87R1) [[2]](diffhunk://#diff-f897effc1c790267dec1c1b968ac6255226e2776d6d6faf458a31d3789389b87R119) [[3]](diffhunk://#diff-f897effc1c790267dec1c1b968ac6255226e2776d6d6faf458a31d3789389b87R553-R595) [[4]](diffhunk://#diff-f897effc1c790267dec1c1b968ac6255226e2776d6d6faf458a31d3789389b87R604-R632) [[5]](diffhunk://#diff-f897effc1c790267dec1c1b968ac6255226e2776d6d6faf458a31d3789389b87L603-R655)
* Integrated tracing into the `RuntimeFiltersPlugin` to record filter status, total filters, and allowed entities, and to wrap filter application in spans. (`lib/runtimeFiltersPlugin/runtimeFiltersPlugin.ts`) [[1]](diffhunk://#diff-c216ff8721af2e4bb24555a9551a0196e8aa3636f3964376d20a5194ecf32e9cR1-R5) [[2]](diffhunk://#diff-c216ff8721af2e4bb24555a9551a0196e8aa3636f3964376d20a5194ecf32e9cR17-R28) [[3]](diffhunk://#diff-c216ff8721af2e4bb24555a9551a0196e8aa3636f3964376d20a5194ecf32e9cR41-R81)
* Added tracing instrumentation to GraphQL execution via a Yoga plugin, wrapping the execution function in a span and recording operation name and exceptions. (`lib/rumble.ts`) [[1]](diffhunk://#diff-12b7b086043246f5db51f0c0bef5cb5a58c1487723bb0360fcbd6ee724751dc1R3-R7) [[2]](diffhunk://#diff-12b7b086043246f5db51f0c0bef5cb5a58c1487723bb0360fcbd6ee724751dc1R235-R265)

**Schema builder enhancements:**

* Registered tracing plugins and configured tracing options in `createSchemaBuilder`, including span wrapper setup and root field detection. (`lib/schemaBuilder.ts`) [[1]](diffhunk://#diff-3515dc6bb881a2f43059afae81da964bd9034823c8218105d7d6918744e5728cR6-R7) [[2]](diffhunk://#diff-3515dc6bb881a2f43059afae81da964bd9034823c8218105d7d6918744e5728cR40-R47) [[3]](diffhunk://#diff-3515dc6bb881a2f43059afae81da964bd9034823c8218105d7d6918744e5728cR79) [[4]](diffhunk://#diff-3515dc6bb881a2f43059afae81da964bd9034823c8218105d7d6918744e5728cR101-R107)

**Configuration and dependencies:**

* Extended `RumbleInput` type to support tracing configuration and options, and updated dependencies to include OpenTelemetry and Pothos tracing packages. (`lib/types/rumbleInput.ts`, `package.json`) [[1]](diffhunk://#diff-1cc2dc6d9450fab1b78c41108673895506c58d3e7e9b15fe27bf0d6f60c75045R1-R3) [[2]](diffhunk://#diff-1cc2dc6d9450fab1b78c41108673895506c58d3e7e9b15fe27bf0d6f60c75045R83-R95) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R40-R45)