### PR TITLE
fix(yoga): allow EnvelopArmorPlugin config to be passed through createYoga

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ server.listen(3000, () => {
 });
 
 ```
+> If you hit `Query depth limit of N exceeded` (or alias/directive/token limit) errors in production, pass `armorConfig` through to relax the [graphql-armor](https://escape.tech/graphql-armor/) defaults — e.g. `createYoga({ armorConfig: { maxDepth: { n: 20 } } })`. `armorConfig` is forwarded verbatim to `EnvelopArmorPlugin(...)` and is only applied when `enableApiDocs` is `false` (i.e. in production).
 
 ## Usage & client generation
 You can use the GraphQL api with any client you like. However, rumble provides a generation api which can output a TypeScript client from a rumble instance. To perform a generation, use the exported function from your rumble instance like this:

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ server.listen(3000, () => {
 });
 
 ```
-> If you hit `Query depth limit of N exceeded` (or alias/directive/token limit) errors in production, pass `armorConfig` through to relax the [graphql-armor](https://escape.tech/graphql-armor/) defaults — e.g. `createYoga({ armorConfig: { maxDepth: { n: 20 } } })`. `armorConfig` is forwarded verbatim to `EnvelopArmorPlugin(...)` and is only applied when `enableApiDocs` is `false` (i.e. in production).
+> If you hit `Query depth limit of N exceeded` (or alias/directive/token limit) errors in production, pass `armorConfig` through to relax the [graphql-armor](https://github.com/Escape-Technologies/graphql-armor) defaults — e.g. `createYoga({ armorConfig: { maxDepth: { n: 20 } } })`. `armorConfig` is forwarded verbatim to `EnvelopArmorPlugin(...)` and is only applied when `enableApiDocs` is `false` (i.e. in production).
 
 ## Usage & client generation
 You can use the GraphQL api with any client you like. However, rumble provides a generation api which can output a TypeScript client from a rumble instance. To perform a generation, use the exported function from your rumble instance like this:

--- a/lib/rumble.ts
+++ b/lib/rumble.ts
@@ -233,7 +233,7 @@ export const db = drizzle(
            * EnvelopArmorPlugin. Only applied when `enableApiDocs` is false
            * (i.e. in production). Useful for relaxing the default depth/alias/
            * directive/token limits when the generated schema legitimately exceeds
-           * them. See https://escape.tech/graphql-armor/ for available options.
+           * them. See https://github.com/Escape-Technologies/graphql-armor for available options.
            *
            * @example
            * createYoga({ armorConfig: { maxDepth: { n: 20 } } })

--- a/lib/rumble.ts
+++ b/lib/rumble.ts
@@ -228,6 +228,17 @@ export const db = drizzle(
            * explorer and will not apply the additional envelop armor plugin.
            */
           enableApiDocs?: boolean;
+          /**
+           * Optional configuration passed to the auto-installed graphql-armor
+           * EnvelopArmorPlugin. Only applied when `enableApiDocs` is false
+           * (i.e. in production). Useful for relaxing the default depth/alias/
+           * directive/token limits when the generated schema legitimately exceeds
+           * them. See https://escape.tech/graphql-armor/ for available options.
+           *
+           * @example
+           * createYoga({ armorConfig: { maxDepth: { n: 20 } } })
+           */
+          armorConfig?: Parameters<typeof EnvelopArmorPlugin>[0];
         })
       | undefined,
   ) => {
@@ -243,7 +254,7 @@ export const db = drizzle(
         ...(args?.plugins ?? []),
         ...(enableApiDocs
           ? []
-          : [useDisableIntrospection(), EnvelopArmorPlugin()]),
+          : [useDisableIntrospection(), EnvelopArmorPlugin(args?.armorConfig)]),
         rumbleInput.otel?.enabled
           ? ({
               // TODO: add trace header per default in http response

--- a/test/src/armor.test.ts
+++ b/test/src/armor.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { buildHTTPExecutor } from "@graphql-tools/executor-http";
+import { parse } from "graphql";
+import { makeSeededDBInstanceForTest } from "./db/db";
+import { makeRumbleSeedInstance } from "./rumble/baseInstance";
+
+// depth-8 path: users -> posts -> comments -> author -> posts -> comments -> author -> id
+const DEEP_QUERY = /* GraphQL */ `
+  query {
+    users {
+      posts {
+        comments {
+          author {
+            posts {
+              comments {
+                author {
+                  id
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+function buildYoga(
+  rumble: ReturnType<typeof makeRumbleSeedInstance>["rumble"],
+  args?: Parameters<
+    ReturnType<typeof makeRumbleSeedInstance>["rumble"]["createYoga"]
+  >[0],
+) {
+  const yogaInstance = rumble.createYoga(args);
+  const executor = buildHTTPExecutor({
+    fetch: yogaInstance.fetch,
+    endpoint: "http://yoga/graphql",
+  });
+  return { yogaInstance, executor };
+}
+
+describe("createYoga armorConfig", async () => {
+  let { db, data } = await makeSeededDBInstanceForTest();
+  // @ts-expect-error
+  let { rumble } = makeRumbleSeedInstance(db, data.users.at(0)?.id, 9);
+
+  beforeEach(async () => {
+    const s = await makeSeededDBInstanceForTest();
+    db = s.db;
+    data = s.data;
+    // @ts-expect-error
+    const r = makeRumbleSeedInstance(db, data.users.at(0)?.id, 9);
+    rumble = r.rumble;
+    rumble.abilityBuilder.users.allow(["read"]);
+    rumble.abilityBuilder.posts.allow(["read"]);
+    rumble.abilityBuilder.comments.allow(["read"]);
+  });
+
+  test("default armor config rejects deep queries in production mode", async () => {
+    const { executor } = buildYoga(rumble, { enableApiDocs: false });
+
+    const r = await executor({ document: parse(DEEP_QUERY) });
+
+    const message = (r as any).errors?.[0]?.message ?? "";
+    expect(message).toMatch(/depth/i);
+  });
+
+  test("custom armorConfig allows deeper queries", async () => {
+    const { executor } = buildYoga(rumble, {
+      enableApiDocs: false,
+      armorConfig: { maxDepth: { n: 10 } },
+    });
+
+    const r = await executor({ document: parse(DEEP_QUERY) });
+
+    expect((r as any).errors).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

The auto-installed `@escape.tech/graphql-armor` `EnvelopArmorPlugin` in `createYoga` uses graphql-armor's defaults, including `maxDepth.n = 6`, which rejects many real-world queries — particularly against Rumble-generated schemas, where Drizzle relation-driven nested selections plus a top-level wrapper trivially produce depth 7+. The plugin is active whenever `enableApiDocs` is `false` (i.e. in production / non-development), so consumers hit `Syntax Error: Query depth limit of 6 exceeded` only in prod while development works fine. Until now there was no escape hatch short of forking — passing extra plugins via `args.plugins` doesn't help because a second armor instance can't relax the first's validation rules.

This PR adds a new optional `armorConfig` option on `createYoga`, forwarded verbatim to `EnvelopArmorPlugin(...)`. Defaults, plugin position, and the presence of `useDisableIntrospection` are all unchanged.

## Changes

- `lib/rumble.ts`: extend the `createYoga` args type with `armorConfig?: Parameters<typeof EnvelopArmorPlugin>[0]` (inferred from the function signature — graphql-armor doesn't directly export a config type, so this avoids pulling in `@escape.tech/graphql-armor-types`). Pass `args?.armorConfig` into `EnvelopArmorPlugin(...)`.
- `README.md`: short note in the "Running the server" section pointing consumers at `armorConfig` when they see depth-limit errors.
- `test/src/armor.test.ts`: new test file with two cases — depth-8 query is rejected with the default armor config, accepted when `armorConfig: { maxDepth: { n: 10 } }` is passed.

Usage:

```ts
createYoga({
  armorConfig: {
    maxDepth: { n: 20 },
    maxAliases: { n: 50 },
    maxDirectives: { n: 50 },
    maxTokens: { n: 5000 },
  },
});
```

## Verification

- `bun run build` — succeeds; `out/index.mjs:1728` and `out/index.cjs:1756` both call `EnvelopArmorPlugin(args?.armorConfig)`; `out/index.d.mts` and `out/index.d.cts` both declare `armorConfig?: Parameters<typeof EnvelopArmorPlugin>[0]`.
- `bun typecheck` — clean.
- `bun test` — 43/43 passing (2 new cases + 41 existing).
- `bun lint` — no new warnings introduced by this PR (one pre-existing `suppressions/unused` in `lib/rumble.ts:347` is unrelated).

## Test plan

- [x] `bun test test/src/armor.test.ts` — both cases pass
- [x] Full `bun test` still green
- [x] `bun typecheck` clean
- [x] Built `out/` artifacts contain `armorConfig` in both types and runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)